### PR TITLE
Improve homepage layout and carousel

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -153,10 +153,15 @@ section {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    background: rgba(0,0,0,0.5);
-    color: #fff;
+    background: rgba(255,255,255,0.7);
+    color: #333;
     border: none;
-    padding: 0.5rem 1rem;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    line-height: 40px;
+    text-align: center;
     cursor: pointer;
     z-index: 1;
     user-select: none;
@@ -164,6 +169,29 @@ section {
 
 .carousel-button.prev { left: 10px; }
 .carousel-button.next { right: 10px; }
+
+.carousel-dots {
+    position: absolute;
+    bottom: 15px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 0.5rem;
+    z-index: 1;
+}
+
+.carousel-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.5);
+    border: none;
+    cursor: pointer;
+}
+
+.carousel-dot.active {
+    background: #fff;
+}
 
 .carousel-track {
     display: flex;

--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -3,6 +3,7 @@ function initCarousel() {
   const track = document.querySelector('.carousel-track');
   const nextBtn = document.querySelector('.carousel-button.next');
   const prevBtn = document.querySelector('.carousel-button.prev');
+  const dotsContainer = document.querySelector('.carousel-dots');
   if (!track || !Array.isArray(slideData)) return;
   track.innerHTML = '';
 
@@ -35,6 +36,16 @@ function initCarousel() {
   slideData.forEach(item => track.appendChild(createSlide(item)));
   track.appendChild(createSlide(slideData[0]));
 
+  if (dotsContainer) {
+    dotsContainer.innerHTML = '';
+    slideData.forEach((_, idx) => {
+      const dot = document.createElement('button');
+      dot.className = 'carousel-dot';
+      dot.addEventListener('click', () => { moveToSlide(idx + 1); resetInterval(); });
+      dotsContainer.appendChild(dot);
+    });
+  }
+
   const slides = Array.from(track.children);
   let index = 1; // start on the first real slide
   let slideWidth = track.getBoundingClientRect().width;
@@ -45,11 +56,21 @@ function initCarousel() {
   };
   window.addEventListener('resize', updateWidth);
 
+  function updateDots() {
+    if (!dotsContainer) return;
+    const dots = dotsContainer.querySelectorAll('.carousel-dot');
+    dots.forEach((d, idx) => {
+      const active = idx === ((index - 1 + slideData.length) % slideData.length);
+      d.classList.toggle('active', active);
+    });
+  }
+
   function moveToSlide(i, animate = true) {
     if (animate) track.style.transition = 'transform 0.5s ease-in-out';
     else track.style.transition = 'none';
     track.style.transform = `translateX(-${i * 100}%)`;
     index = i;
+    updateDots();
   }
 
   track.addEventListener('transitionend', () => {
@@ -58,6 +79,7 @@ function initCarousel() {
     } else if (index === slideData.length + 1) {
       moveToSlide(1, false);
     }
+    updateDots();
   });
 
   const next = () => { moveToSlide(index + 1); resetInterval(); };
@@ -112,6 +134,7 @@ function initCarousel() {
   window.addEventListener('mouseleave', endDrag);
 
   moveToSlide(index, false);
+  updateDots();
   let interval = setInterval(() => moveToSlide(index + 1), 3000);
   function resetInterval() {
     clearInterval(interval);

--- a/assets/js/products.js
+++ b/assets/js/products.js
@@ -1,18 +1,28 @@
+function renderProducts(containerId, lang) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = '';
+  productData.forEach(p => {
+    const t = p[lang] || p.en;
+    const item = document.createElement('div');
+    item.className = 'product-item';
+    item.innerHTML = `
+      <a href="product-detail.html?id=${p.id}">
+        <img src="${p.image}" alt="${t.name}">
+        <h3>${t.name}</h3>
+      </a>
+      <p>${t.short}</p>`;
+    container.appendChild(item);
+  });
+}
+
+function updateProducts(lang) {
+  ['products-container', 'home-products'].forEach(id => renderProducts(id, lang));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  const container = document.getElementById('products-container');
   const lang = localStorage.getItem('lang') || 'en';
-  if (container) {
-    productData.forEach(p => {
-      const t = p[lang] || p.en;
-      const item = document.createElement('div');
-      item.className = 'product-item';
-      item.innerHTML = `
-        <a href="product-detail.html?id=${p.id}">
-          <img src="${p.image}" alt="${t.name}">
-          <h3>${t.name}</h3>
-        </a>
-        <p>${t.short}</p>`;
-      container.appendChild(item);
-    });
-  }
+  updateProducts(lang);
+  const switcher = document.getElementById('lang-switch');
+  if (switcher) switcher.addEventListener('change', e => updateProducts(e.target.value));
 });

--- a/index.html
+++ b/index.html
@@ -36,36 +36,24 @@
         <section class="hero">
             <div class="carousel">
                 <button class="carousel-button prev">&#10094;</button>
-                <div class="carousel-track">
-                </div>
+                <div class="carousel-track"></div>
                 <button class="carousel-button next">&#10095;</button>
+                <div class="carousel-dots"></div>
+            </div>
+        </section>
+
+        <section class="about">
+            <div class="container">
+                <h2 data-i18n="aboutHeading">About Us</h2>
+                <p data-i18n="aboutPara1">AYES DEFENSE CORPORATION supplies premium ammunition to government and civilian markets.</p>
+                <p data-i18n="aboutPara2">With decades of experience, we focus on safety, precision and lasting partnerships.</p>
             </div>
         </section>
 
         <section>
             <div class="container">
-                <h2 data-i18n="welcomeHeading">Welcome to AYES DEFENSE CORPORATION</h2>
-                <p data-i18n="welcomeText">We provide state-of-the-art ammunition solutions for defense and sporting needs. This is placeholder text you can replace with your own content.</p>
-            </div>
-        </section>
-
-        <section class="features">
-            <div class="container">
-                <div class="feature">
-                    <img src="https://picsum.photos/400/300" alt="Precision">
-                    <h3 data-i18n="featuresPrecisionHeading">Precision Engineering</h3>
-                    <p data-i18n="featuresPrecisionText">Every round is manufactured with exacting tolerances for superior accuracy.</p>
-                </div>
-                <div class="feature">
-                    <img src="https://picsum.photos/400/301" alt="Reliability">
-                    <h3 data-i18n="featuresReliabilityHeading">Reliable Performance</h3>
-                    <p data-i18n="featuresReliabilityText">Our ammunition is tested to perform flawlessly in any environment.</p>
-                </div>
-                <div class="feature">
-                    <img src="https://picsum.photos/400/302" alt="Innovation">
-                    <h3 data-i18n="featuresInnovationHeading">Innovative Solutions</h3>
-                    <p data-i18n="featuresInnovationText">We continually develop new products to meet evolving mission needs.</p>
-                </div>
+                <h2 data-i18n="ourProductsHeading">Our Products</h2>
+                <div id="home-products" class="products"></div>
             </div>
         </section>
     </main>
@@ -78,5 +66,13 @@
 
     <script src="assets/data/slide-data.js"></script>
     <script src="assets/js/carousel.js"></script>
+    <script src="assets/data/product-data.js"></script>
+    <script src="assets/js/products.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const lang = localStorage.getItem('lang') || 'en';
+            if (typeof updateProducts === 'function') updateProducts(lang);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace feature cards with about section and product previews on `index.html`
- add dot indicators and modern styling to carousel
- show products in both pages and refresh when language changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431f930a588323a2fb7ab7eacf69bd