### PR TITLE
Enhance carousel and typing effects

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -217,19 +217,23 @@ section {
 
 .slide-text {
     position: absolute;
-    left: 50%;
-    bottom: 20px;
-    transform: translateX(-50%);
+    left: 0;
+    right: 0;
+    bottom: 0;
     color: #fff;
     background: rgba(0, 0, 0, 0.6);
     padding: 1rem 1.5rem;
-    border-radius: 5px;
-    font-size: 1.5rem;
+    font-size: 1.25rem;
     font-weight: bold;
     text-align: center;
-    max-width: 90%;
     text-shadow: 0 2px 4px rgba(0,0,0,0.6);
     pointer-events: none;
+}
+
+.carousel-control-prev span,
+.carousel-control-next span {
+    font-size: 2rem;
+    color: #fff;
 }
 
 .about {

--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -15,7 +15,7 @@ function initCarousel() {
       <div class="carousel-item ${active}">
         <a href="slide-detail.html?id=${item.id}">
           <img src="${item.image}" class="d-block w-100" alt="Carousel slide">
-          <div class="carousel-caption d-none d-md-block">
+          <div class="carousel-caption">
             <h5 class="slide-text">${text}</h5>
           </div>
         </a>
@@ -24,7 +24,8 @@ function initCarousel() {
       <button type="button" data-bs-target="#homeCarousel" data-bs-slide-to="${idx}" ${active ? 'class="active" aria-current="true"' : ''} aria-label="Slide ${idx + 1}"></button>`);
   });
 
-  new bootstrap.Carousel(carousel, { interval: 3000, ride: 'carousel' });
+  const bsCarousel = new bootstrap.Carousel(carousel, { interval: 3000, ride: 'carousel' });
+  enableCarouselDrag(carousel, bsCarousel);
 }
 
 document.addEventListener('DOMContentLoaded', initCarousel);
@@ -37,4 +38,37 @@ function updateCarouselLang(lang) {
     const caption = slide.querySelector('.slide-text');
     if (caption) caption.textContent = (data[lang] || data.en).text;
   });
+}
+
+function enableCarouselDrag(element, instance) {
+  let startX = null;
+  let deltaX = 0;
+  const threshold = 40;
+
+  element.addEventListener('mousedown', start);
+  element.addEventListener('touchstart', start, { passive: true });
+  element.addEventListener('mousemove', move);
+  element.addEventListener('touchmove', move, { passive: true });
+  element.addEventListener('mouseup', end);
+  element.addEventListener('touchend', end);
+  element.addEventListener('mouseleave', end);
+
+  function start(e) {
+    startX = e.touches ? e.touches[0].clientX : e.clientX;
+    deltaX = 0;
+  }
+
+  function move(e) {
+    if (startX === null) return;
+    const currentX = e.touches ? e.touches[0].clientX : e.clientX;
+    deltaX = currentX - startX;
+  }
+
+  function end(e) {
+    if (startX === null) return;
+    if (Math.abs(deltaX) > threshold) {
+      deltaX < 0 ? instance.next() : instance.prev();
+    }
+    startX = null;
+  }
 }

--- a/assets/js/typing.js
+++ b/assets/js/typing.js
@@ -1,16 +1,28 @@
-function typeWrite(selector, speed = 40) {
-  document.querySelectorAll(selector).forEach(el => {
+function typeWriteSequential(elements, speed = 40) {
+  let index = 0;
+  function typeNext() {
+    if (index >= elements.length) return;
+    const el = elements[index];
     const text = el.textContent;
     el.textContent = '';
     let i = 0;
     const timer = setInterval(() => {
       el.textContent += text.charAt(i);
       i++;
-      if (i >= text.length) clearInterval(timer);
+      if (i >= text.length) {
+        clearInterval(timer);
+        index++;
+        typeNext();
+      }
     }, speed);
-  });
+  }
+  typeNext();
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  typeWrite('.about-typing p');
+  const aboutSection = document.querySelector('.about-typing');
+  if (aboutSection) {
+    const items = aboutSection.querySelectorAll('h2, p');
+    typeWriteSequential(items);
+  }
 });

--- a/contact.html
+++ b/contact.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>
@@ -45,11 +46,11 @@
                 <div class="carousel-indicators"></div>
                 <div class="carousel-inner"></div>
                 <button class="carousel-control-prev" type="button" data-bs-target="#homeCarousel" data-bs-slide="prev">
-                    <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                    <span class="fa-solid fa-chevron-left" aria-hidden="true"></span>
                     <span class="visually-hidden">Previous</span>
                 </button>
                 <button class="carousel-control-next" type="button" data-bs-target="#homeCarousel" data-bs-slide="next">
-                    <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                    <span class="fa-solid fa-chevron-right" aria-hidden="true"></span>
                     <span class="visually-hidden">Next</span>
                 </button>
             </div>

--- a/product-detail.html
+++ b/product-detail.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>

--- a/products.html
+++ b/products.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>

--- a/slide-detail.html
+++ b/slide-detail.html
@@ -9,6 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600&family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <link rel="icon" href="assets/images/logo.svg">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="assets/css/styles.css">
     <script src="assets/i18n/lang-en.js"></script>
     <script src="assets/i18n/lang-tr.js"></script>


### PR DESCRIPTION
## Summary
- enable drag/swipe for the homepage carousel
- display caption overlay text on all screen sizes
- sequential typing effect for About sections
- include Font Awesome icons and modernize carousel controls
- adjust slide caption styling

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68432d7aa39483238c8299dc13a63949