### PR TITLE
Fix carousel initialization

### DIFF
--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -145,7 +145,15 @@ function initCarousel() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', initCarousel);
+function onReady(fn) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fn);
+  } else {
+    fn();
+  }
+}
+
+onReady(initCarousel);
 
 function updateCarouselLang(lang) {
   document.querySelectorAll('.carousel-track .carousel-item').forEach(slide => {


### PR DESCRIPTION
## Summary
- initialize carousel immediately if DOM is already ready

## Testing
- `node -c assets/js/carousel.js`

------
https://chatgpt.com/codex/tasks/task_e_68433a6cd4dc832380559c2cf4ec7ca8