### PR TITLE
Improve menu and carousel UX

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -262,13 +262,17 @@ section {
         width: 200px;
         background: var(--color-bg-dark);
         padding: 1rem;
-        display: none;
         flex-direction: column;
         align-items: flex-end;
+        transform: translateY(-20px);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s;
     }
     nav.open {
-        display: flex;
-        animation: slideDown 0.3s ease forwards;
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
     }
     nav ul {
         flex-direction: column;
@@ -279,54 +283,48 @@ section {
         display: flex;
     }
 }
-@keyframes slideDown {
-    from { transform: translateY(-10px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-}
 
 /* Carousel */
 .carousel {
     position: relative;
     overflow: hidden;
 }
-.carousel-slide {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    opacity: 0;
-    transition: opacity 0.5s ease;
+.carousel-track {
+    display: flex;
+    transition: transform 0.5s ease-in-out;
 }
-.carousel-slide.active {
-    opacity: 1;
+.carousel-item {
+    min-width: 100%;
     position: relative;
 }
-.carousel-slide img {
+.carousel-item img {
     width: 100%;
     height: auto;
     display: block;
+    user-select: none;
 }
 .carousel-caption {
     position: absolute;
     bottom: 1rem;
     left: 1rem;
-    background: rgba(0,0,0,0.5);
+    background: rgba(0, 0, 0, 0.5);
     color: #fff;
     padding: 0.5rem 1rem;
     border-radius: 3px;
 }
-.carousel-arrow {
+.carousel-button {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    background: rgba(0,0,0,0.5);
+    background: rgba(0, 0, 0, 0.5);
     color: #fff;
     border: none;
     padding: 0.5rem;
     cursor: pointer;
+    z-index: 2;
 }
-#prev-slide { left: 10px; }
-#next-slide { right: 10px; }
+.carousel-button.prev { left: 10px; }
+.carousel-button.next { right: 10px; }
 .carousel-dots {
     position: absolute;
     bottom: 1rem;
@@ -334,6 +332,7 @@ section {
     transform: translateX(-50%);
     display: flex;
     gap: 0.5rem;
+    z-index: 2;
 }
 .carousel-dot {
     width: 10px;

--- a/assets/js/carousel.js
+++ b/assets/js/carousel.js
@@ -1,29 +1,108 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const slides = Array.from(document.querySelectorAll('.carousel-slide'));
-  const prev = document.getElementById('prev-slide');
-  const next = document.getElementById('next-slide');
+function initCarousel() {
+  const track = document.querySelector('.carousel-track');
+  const nextBtn = document.querySelector('.carousel-button.next');
+  const prevBtn = document.querySelector('.carousel-button.prev');
+  if (!track) return;
+
+  const originalSlides = Array.from(track.children);
+  if (originalSlides.length === 0) return;
+
+  // add clones for seamless looping
+  track.insertBefore(originalSlides[originalSlides.length - 1].cloneNode(true), track.firstChild);
+  track.appendChild(originalSlides[0].cloneNode(true));
+  const slides = Array.from(track.children);
+
+  let index = 1;
+  let slideWidth = track.getBoundingClientRect().width;
+
+  const updateWidth = () => {
+    slideWidth = track.getBoundingClientRect().width;
+    moveToSlide(index, false);
+  };
+  window.addEventListener('resize', updateWidth);
+
+  function moveToSlide(i, animate = true) {
+    if (animate) track.style.transition = 'transform 0.5s ease-in-out';
+    else track.style.transition = 'none';
+    track.style.transform = `translateX(-${i * 100}%)`;
+    index = i;
+    updateDots();
+  }
+
+  track.addEventListener('transitionend', () => {
+    if (index === 0) {
+      moveToSlide(originalSlides.length, false);
+    } else if (index === originalSlides.length + 1) {
+      moveToSlide(1, false);
+    }
+  });
+
+  const next = () => { moveToSlide(index + 1); resetInterval(); };
+  const prev = () => { moveToSlide(index - 1); resetInterval(); };
+
+  if (nextBtn) nextBtn.addEventListener('click', next);
+  if (prevBtn) prevBtn.addEventListener('click', prev);
+
   const dots = Array.from(document.querySelectorAll('.carousel-dot'));
-  const carousel = document.querySelector('.carousel');
-  let current = 0;
-  function show(index) {
-    slides.forEach((s, i) => {
-      s.classList.toggle('active', i === index);
-      if (dots[i]) dots[i].classList.toggle('active', i === index);
-    });
-    current = index;
+  function updateDots() {
+    const activeIndex = (index - 1 + originalSlides.length) % originalSlides.length;
+    dots.forEach((d, i) => d.classList.toggle('active', i === activeIndex));
   }
-  if (next) next.addEventListener('click', () => show((current + 1) % slides.length));
-  if (prev) prev.addEventListener('click', () => show((current - 1 + slides.length) % slides.length));
-  dots.forEach((d, i) => d.addEventListener('click', () => show(i)));
-  let startX;
-  if (carousel) {
-    carousel.addEventListener('mousedown', e => { startX = e.clientX; carousel.classList.add('dragging'); });
-    carousel.addEventListener('mouseup', e => {
-      const diff = e.clientX - startX;
-      if (diff > 50) prev.click();
-      if (diff < -50) next.click();
-      carousel.classList.remove('dragging');
-    });
+  dots.forEach((d, i) => d.addEventListener('click', () => {
+    moveToSlide(i + 1);
+    resetInterval();
+  }));
+
+  let isDragging = false;
+  let startX = 0;
+  let moveX = 0;
+  let hasMoved = false;
+
+  const getEventX = (e) => (e.touches ? e.touches[0].clientX : e.clientX);
+
+  const startDrag = (e) => {
+    e.preventDefault();
+    isDragging = true;
+    startX = getEventX(e);
+    moveX = 0;
+    hasMoved = false;
+    track.style.transition = 'none';
+  };
+
+  const duringDrag = (e) => {
+    if (!isDragging) return;
+    moveX = getEventX(e) - startX;
+    if (Math.abs(moveX) > 5) hasMoved = true;
+    const movePercent = (moveX / slideWidth) * 100;
+    track.style.transform = `translateX(calc(-${index * 100}% + ${movePercent}%))`;
+  };
+
+  const endDrag = () => {
+    if (!isDragging) return;
+    isDragging = false;
+    track.style.transition = 'transform 0.5s ease-in-out';
+    if (Math.abs(moveX) > slideWidth / 4) {
+      if (moveX < 0) index += 1; else index -= 1;
+    }
+    moveToSlide(index);
+    resetInterval();
+  };
+
+  track.addEventListener('mousedown', startDrag);
+  track.addEventListener('touchstart', startDrag, { passive: true });
+  window.addEventListener('mousemove', duringDrag);
+  track.addEventListener('click', (e) => { if (hasMoved) e.preventDefault(); }, true);
+  window.addEventListener('touchmove', duringDrag, { passive: true });
+  window.addEventListener('mouseup', endDrag);
+  window.addEventListener('touchend', endDrag);
+  window.addEventListener('mouseleave', endDrag);
+
+  moveToSlide(index, false);
+  let interval = setInterval(() => moveToSlide(index + 1), 4000);
+  function resetInterval() {
+    clearInterval(interval);
+    interval = setInterval(() => moveToSlide(index + 1), 4000);
   }
-  show(0);
-});
+}
+
+document.addEventListener('DOMContentLoaded', initCarousel);

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -2,8 +2,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const burger = document.getElementById('hamburger');
   const nav = document.getElementById('main-nav');
   if (!burger || !nav) return;
-  burger.addEventListener('click', () => {
+
+  const toggleMenu = () => {
     nav.classList.toggle('open');
     burger.classList.toggle('open');
+  };
+
+  burger.addEventListener('click', toggleMenu);
+
+  nav.querySelectorAll('a').forEach(link =>
+    link.addEventListener('click', () => {
+      if (nav.classList.contains('open')) toggleMenu();
+    })
+  );
+
+  document.addEventListener('click', (e) => {
+    if (nav.classList.contains('open') && !nav.contains(e.target) && e.target !== burger) {
+      toggleMenu();
+    }
   });
 });

--- a/index.html
+++ b/index.html
@@ -44,29 +44,31 @@
 
     <main>
         <section class="carousel">
-            <div class="carousel-slide active">
-                <img src="https://picsum.photos/1200/400?1" alt="Slide 1">
-                <div class="carousel-caption">
-                    <h2 data-i18n="carouselHeading1">Trusted Performance</h2>
-                    <p data-i18n="carouselText1">Precision ammunition for every mission.</p>
+            <div class="carousel-track">
+                <div class="carousel-item">
+                    <img src="https://picsum.photos/1200/400?1" alt="Slide 1">
+                    <div class="carousel-caption">
+                        <h2 data-i18n="carouselHeading1">Trusted Performance</h2>
+                        <p data-i18n="carouselText1">Precision ammunition for every mission.</p>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <img src="https://picsum.photos/1200/401?2" alt="Slide 2">
+                    <div class="carousel-caption">
+                        <h2 data-i18n="carouselHeading2">Engineered for Reliability</h2>
+                        <p data-i18n="carouselText2">Consistent quality round after round.</p>
+                    </div>
+                </div>
+                <div class="carousel-item">
+                    <img src="https://picsum.photos/1200/402?3" alt="Slide 3">
+                    <div class="carousel-caption">
+                        <h2 data-i18n="carouselHeading3">Innovating Ammunition</h2>
+                        <p data-i18n="carouselText3">Advancing technology for defense.</p>
+                    </div>
                 </div>
             </div>
-            <div class="carousel-slide">
-                <img src="https://picsum.photos/1200/401?2" alt="Slide 2">
-                <div class="carousel-caption">
-                    <h2 data-i18n="carouselHeading2">Engineered for Reliability</h2>
-                    <p data-i18n="carouselText2">Consistent quality round after round.</p>
-                </div>
-            </div>
-            <div class="carousel-slide">
-                <img src="https://picsum.photos/1200/402?3" alt="Slide 3">
-                <div class="carousel-caption">
-                    <h2 data-i18n="carouselHeading3">Innovating Ammunition</h2>
-                    <p data-i18n="carouselText3">Advancing technology for defense.</p>
-                </div>
-            </div>
-            <button id="prev-slide" class="carousel-arrow" aria-label="Previous slide">&#10094;</button>
-            <button id="next-slide" class="carousel-arrow" aria-label="Next slide">&#10095;</button>
+            <button class="carousel-button prev" aria-label="Previous slide">&#10094;</button>
+            <button class="carousel-button next" aria-label="Next slide">&#10095;</button>
             <div class="carousel-dots">
                 <span class="carousel-dot active"></span>
                 <span class="carousel-dot"></span>


### PR DESCRIPTION
## Summary
- rework mobile nav animation for smooth open and close
- close the nav when clicking outside or on a menu link
- rebuild carousel markup and styling
- add new infinite carousel script with drag support

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843506209488323b8a9bab181e1fd71