### PR TITLE
Improve carousel dot styling

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -327,24 +327,29 @@ section {
 .carousel-button.next { right: 10px; }
 .carousel-dots {
     position: absolute;
-    bottom: 1rem;
+    bottom: 0.5rem;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     gap: 0.5rem;
+    padding: 0.25rem 0.6rem;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 1rem;
     z-index: 2;
 }
 .carousel-dot {
-    width: 10px;
-    height: 10px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
-    background: #fff;
-    opacity: 0.5;
+    background: #ccc;
+    opacity: 0.9;
+    border: 1px solid #fff;
     cursor: pointer;
 }
 .carousel-dot.active {
     opacity: 1;
     background: var(--color-accent);
+    border-color: var(--color-accent);
 }
 .carousel.dragging {
     cursor: grabbing;


### PR DESCRIPTION
## Summary
- refine carousel dot colors and container style for a sleeker look

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684351aec7e883238ad5234d89bacad3